### PR TITLE
Handle HoldTime of 0 properly

### DIFF
--- a/draft-ietf-idr-bgp-sendholdtimer.xml
+++ b/draft-ietf-idr-bgp-sendholdtimer.xml
@@ -224,7 +224,7 @@
             <t hangText="-">changes its state to Idle.</t>
           </list>
         </t>
-        <t>Each time the local system sends a KEEPALIVE, UPDATE, and/or NOTIFICATION message, it restarts its SendHoldTimer.</t>
+        <t>Each time the local system sends a KEEPALIVE, UPDATE, and/or NOTIFICATION message, it restarts its SendHoldTimer unless the negotiated HoldTime value is zero in which case the SendHoldTimer is stopped.</t>
       </list>
     </t>
   </section>


### PR DESCRIPTION
When a HoldTime of 0 was negotiated then KEEEPALIVE messages are not sent and there is no HoldTimer running. In that case also the SendHoldTimer needs to be stopped.

See also:
https://mailarchive.ietf.org/arch/msg/idr/6B6Jc7oVLvNOTsxe5uhaEHBmG1o/