### PR TITLE
Cosmetic changes

### DIFF
--- a/draft-ietf-idr-bgp-sendholdtimer.xml
+++ b/draft-ietf-idr-bgp-sendholdtimer.xml
@@ -10,7 +10,7 @@
 
 <rfc
   category="std"
-  docName="draft-ietf-idr-bgp-sendholdtimer-12"
+  docName="draft-ietf-idr-bgp-sendholdtimer-13"
   updates="4271"
   ipr="trust200902"
   submissionType="IETF"
@@ -90,7 +90,7 @@
   <section title="Introduction">
 
     <t>
-      This document defines the SendHoldtimer, along with the SendHoldTimer_Expires event, for the Border Gateway Protocol (BGP) <xref target="RFC4271" /> Finite State Machine (FSM) defined in section 8.
+      This document defines the <tt>SendHoldtimer</tt>, along with the <tt>SendHoldTimer_Expires</tt> event, for the Border Gateway Protocol (BGP) <xref target="RFC4271" /> Finite State Machine (FSM) defined in section 8.
     </t>
 
     <t>
@@ -98,7 +98,7 @@
       This phenomena is thought to have contributed to IP traffic blackholing events in the global Internet routing system <xref target="bgpzombies"/>.
     </t>
     <t>
-      This specification intends to improve this situation by requiring that BGP connections be terminated if the local system has detected that the remote system cannot possibly have processed any BGP messages for the duration of the SendHoldTime.
+      This specification intends to improve this situation by requiring that BGP connections be terminated if the local system has detected that the remote system cannot possibly have processed any BGP messages for the duration of the <tt>SendHoldTime</tt>.
       Through standardization of the aforementioned requirement, operators will benefit from consistent behavior across different BGP implementations.
     </t>
     <t>
@@ -109,7 +109,7 @@
 
   <section title="Example of a problematic scenario">
     <t>
-      In implementations lacking the concept of a SendHoldTimer, a malfunctioning or overwhelmed remote speaker may cause data on the BGP socket in the local system to accumulate ad infinitum.
+      In implementations lacking the concept of a <tt>SendHoldTimer</tt>, a malfunctioning or overwhelmed remote speaker may cause data on the BGP socket in the local system to accumulate ad infinitum.
       This could result in forwarding failure and traffic loss, as the overwhelmed speaker continues to utilize stale routes.
     </t>
     <t>
@@ -130,11 +130,11 @@
     </t>
   </section>
 
-  <section title="SendHoldTimer - Changes to RFC 4271">
+  <section title="Changes to RFC 4271 - SendHoldTimer">
 
   <t>
     BGP speakers are implemented following a conceptual model "BGP Finite State Machine" (FSM), which is outlined in section 8 of <xref target="RFC4271"/>.
-    This specification adds a BGP timer, SendHoldTimer, and updates the BGP FSM as follows:
+    This specification adds a BGP timer, <tt>SendHoldTimer</tt>, and updates the BGP FSM as follows:
   </t>
 
   <section title="Session Attributes">
@@ -142,7 +142,8 @@
       The following optional session attributes for each connection are added to Section 8, before "The optional session attributes support different features of the BGP functionality that have implications for the BGP FSM state transitions":
     </t>
 
-    <t>
+    <t>NEW</t>
+    <blockquote>
       <list style="empty">
         <t>
           14) SendHoldTimer
@@ -151,11 +152,11 @@
           15) SendHoldTime
         </t>
       </list>
-    </t>
+    </blockquote>
 
     <t>
-      The SendHoldTime determines how long a BGP speaker will stay in Established state before the TCP connection is dropped because no BGP messages can be transmitted to its peer.
-      A BGP speaker can configure the value of the SendHoldTime to each peer independently.
+      The <tt>SendHoldTime</tt> determines how long a BGP speaker will stay in Established state before the TCP connection is dropped because no BGP messages can be transmitted to its peer.
+      A BGP speaker can configure the value of the <tt>SendHoldTime</tt> for each peer independently.
     </t>
   </section>
 
@@ -163,48 +164,58 @@
   <t>
     Another timer event is added to Section 8.1.3 of <xref target="RFC4271"/> as following:
   </t>
-  <dl newline="true">
-    <dt>Event 29: SendHoldTimer_Expires</dt>
-    <dd>
-      <dl>
-      <dt>Definition:</dt>
-      <dd>An event generated when the SendHoldTimer expires. </dd>
-      <dt>Status:</dt>
-      <dd>Optional</dd>
-      </dl>
-    </dd>
-  </dl>
+
+  <t>NEW</t>
+  <blockquote>
+    <dl newline="true">
+      <dt>
+        Event 29: SendHoldTimer_Expires
+      </dt>
+      <dd>
+        <dl>
+          <dt>Definition:</dt>
+          <dd>An event generated when the SendHoldTimer expires.</dd>
+          <dt>Status:</dt>
+          <dd>Optional</dd>
+        </dl>
+      </dd>
+    </dl>
+  </blockquote>
   </section>
 
   <section title="Changes to the FSM">
     <t>The following changes are made to section 8.2.2 in <xref target="RFC4271"/>.</t>
     <t>In "OpenConfirm State", the handling of Event 26 is revised as follows:</t>
-    <dl newline="true">
-      <dt>Old Text:</dt>
-      <dd>
-        <t>If the local system receives a KEEPALIVE message (KeepAliveMsg
-           (Event 26)), the local system:
-          <list style="hanging">
-            <t hangText="-">restarts the HoldTimer and</t>
-            <t hangText="-">changes its state to Established.</t>
-          </list></t>
-      </dd>
-      <dt>New Text:</dt>
-      <dd>
-        <t>If the local system receives a KEEPALIVE message (KeepAliveMsg
-           (Event 26)), the local system:
-          <list style="hanging">
-            <t hangText="-">restarts the HoldTimer,</t>
-            <t hangText="-">starts the SendHoldTimer if the SendHoldTime is non-zero, and</t>
-            <t hangText="-">changes its state to Established.</t>
-          </list></t>
-      </dd>
-    </dl>
 
-    <t>The following paragraph is added to section 8.2.2 in "Established State",
-      after the paragraph which ends "unless the negotiated HoldTime value
-      is zero.":</t>
+    <t>OLD</t>
+    <blockquote>
       <t>
+        If the local system receives a KEEPALIVE message (KeepAliveMsg (Event 26)), the local system:
+        <list style="hanging">
+          <t hangText="-">restarts the HoldTimer and</t>
+          <t hangText="-">changes its state to Established.</t>
+        </list>
+      </t>
+    </blockquote>
+
+    <t>NEW</t>
+    <blockquote>
+      <t>
+        If the local system receives a KEEPALIVE message (KeepAliveMsg (Event 26)), the local system:
+        <list style="hanging">
+          <t hangText="-">restarts the HoldTimer,</t>
+          <t hangText="-">starts the SendHoldTimer if the SendHoldTime is non-zero, and</t>
+          <t hangText="-">changes its state to Established.</t>
+        </list>
+      </t>
+    </blockquote>
+
+    <t>
+      The following paragraph is added to section 8.2.2 in "Established State", after the paragraph which ends "unless the negotiated HoldTime value is zero.":
+    </t>
+
+    <t>NEW</t>
+    <blockquote>
       <list style="empty">
         <t>If the SendHoldTimer_Expires (Event 29), the local system:
           <list style="hanging">
@@ -225,39 +236,48 @@
           The SendHoldTimer is stopped following any transition out of the Established state as part of the "release all BGP resources" action.
         </t>
       </list>
-    </t>
+    </blockquote>
   </section>
 
   <section title="Changes to BGP Timers" anchor="timers">
-    <t><xref target="RFC4271" section="10"/> summarizes BGP Timers. This document adds another optional BGP timer: SendHoldTimer.</t>
-    <t>SendHoldTime is an FSM attribute that stores the initial value for the SendHoldTimer. If SendHoldTime is non-zero then it MUST be greater than the value of HoldTime, see <xref target="implcons"/> for suggested default values.</t>
+    <t>
+      <xref target="RFC4271" section="10"/> summarizes BGP Timers.
+      This document adds another optional BGP timer: <tt>SendHoldTimer</tt>.
+    </t>
+    <t>NEW</t>
+    <blockquote>
+      <t>
+        SendHoldTime is an FSM attribute that stores the initial value for the SendHoldTimer.
+        If SendHoldTime is non-zero then it MUST be greater than the value of HoldTime, see <xref target="implcons"/> for suggested default values.
+      </t>
+    </blockquote>
   </section>
 
   </section>
 
   <section title="Send Hold Timer Expired Error Handling">
     <t>
-      If the local system does not send any BGP messages within the period specified in SendHoldTime, then a NOTIFICATION message with the "Send Hold Timer Expired" Error Code MAY be sent and the BGP connection MUST be closed.
+      If the local system does not send any BGP messages within the period specified in <tt>SendHoldTime</tt>, then a NOTIFICATION message with the "Send Hold Timer Expired" Error Code MAY be sent and the BGP connection MUST be closed.
       Additionally, an error MUST be logged in the local system, indicating the Send Hold Timer Expired Error Code.
     </t>
   </section>
 
   <section title="Implementation Considerations" anchor="implcons">
     <t>
-      Due to the relative rarity of the failure mode that this specification is designed to address, and also the fact that network operators may be unfamiliar with the formal specification of BGP fault detection mechanisms such as HoldTimer, it is likely that a large number of operators are unaware of the necessity of an additional mechanism such as SendHoldtimer.
+      Due to the relative rarity of the failure mode that this specification is designed to address, and also the fact that network operators may be unfamiliar with the formal specification of BGP fault detection mechanisms such as <tt>HoldTimer</tt>, it is likely that a large number of operators are unaware of the necessity of an additional mechanism such as <tt>SendHoldtimer</tt>.
     </t>
     <t>
-      Accordingly, it is RECOMMENDED that implementations of this specification enable SendHoldtimer by default, without requiring additional configuration of the BGP speaking device.
+      Accordingly, it is RECOMMENDED that implementations of this specification enable <tt>SendHoldtimer</tt> by default, without requiring additional configuration of the BGP speaking device.
     </t>
     <t>
-      The default value of SendHoldTime for a BGP connection SHOULD be the greater of:
-      <list style="hanging">
-        <t hangText="-">8 minutes; or</t>
-        <t hangText="-">2 times the negotiated HoldTime</t>
-      </list>
+      The default value of <tt>SendHoldTime</tt> for a BGP connection SHOULD be the greater of:
+      <ul>
+        <li>8 minutes; or</li>
+        <li>2 times the negotiated HoldTime</li>
+      </ul>
     </t>
     <t>
-      Implementations MAY make the value of SendHoldTime configurable, either globally or on a per-peer basis, within the constraints set out in <xref target="timers"/> above.
+      Implementations MAY make the value of <tt>SendHoldTime</tt> configurable, either globally or on a per-peer basis, within the constraints set out in <xref target="timers"/> above.
     </t>
     <t>
       The subcode for NOTIFICATION message "Send Hold Timer Expired" is set to 0 and is not used, no additional data is to be appended to the end of a "Send Hold Timer Expired" NOTIFICATION message.
@@ -266,7 +286,7 @@
 
   <section title="Operational Considerations">
     <t>
-      When the local system recognizes a remote speaker is not processing any BGP messages for the duration of the SendHoldTime, it is likely that the local system will not be able to inform the remote peer through a NOTIFICATION message as to why the connection is being closed.
+      When the local system recognizes a remote speaker is not processing any BGP messages for the duration of the <tt>SendHoldTime</tt>, it is likely that the local system will not be able to inform the remote peer through a NOTIFICATION message as to why the connection is being closed.
       This documents suggests that an attempt to send a NOTIFICATION message with the "Send Hold Timer Expired" error code is still made, if doing so will not delay closing the BGP connection.
       Meanwhile an error message is logged into the local system.
     </t>
@@ -277,7 +297,7 @@
 
   <section title="Security Considerations">
     <t>
-      This specification does not change BGP's security characteristics. Implementing the BGP SendHoldTimer as specified in this document will enhance network resilience by terminating connections with malfunctioning or overwhelmed remote peers.
+      This specification does not change BGP's security characteristics. Implementing the BGP <tt>SendHoldTimer</tt> as specified in this document will enhance network resilience by terminating connections with malfunctioning or overwhelmed remote peers.
     </t>
   </section>
 


### PR DESCRIPTION
From recent RFC publication experiences, I noticed that the RFC editor makes good use of modern `xml2rfc` display abilities in the HTML output (not to be confused with `htmlized`). Additionally, I believe the TXT output is also improved by using blockquotes. Formatting things this way might make it easier for IESG people to understand the changes the document introduces, then again it is a bit late in the game.

The RFC editor might introduce changes like these anyway when it comes to that point

The changes introduces by this PR should be of *only* cosmetic nature 

also paging @jhaas-pfrc